### PR TITLE
design, fix: SDK 31이하 스플래시 대응

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,4 +160,8 @@ dependencies {
 
     //Lottie
     implementation ("com.airbnb.android:lottie:6.0.0")
+
+    //splash 아이콘 숨기기
+    implementation ("androidx.core:core-splashscreen:1.0.0-beta01")
+
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/splash/SplashActivity.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/splash/SplashActivity.kt
@@ -19,11 +19,10 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun loadSplashScreen() {
-        lifecycleScope.launch {
-            delay(1000)
-            val intent = Intent(this@SplashActivity, MainActivity::class.java)
+        Handler(Looper.getMainLooper()).postDelayed({
+            val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()
-        }
+        }, 1000)
     }
 }

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -5,5 +5,6 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+
     </style>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -5,5 +5,6 @@
         <item name="android:windowBackground">@color/background_light</item>
         <item name="android:colorBackground">@color/background_light</item>
         <item name="android:windowSplashScreenAnimatedIcon">@android:color/transparent</item>
+
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,7 +3,8 @@
     <style name="Base.Theme.KekKek" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:windowBackground">@color/background_light</item>
         <item name="android:colorBackground">@color/background_light</item>
-        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="S">@android:color/transparent</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowIsTranslucent">true</item>
     </style>
 
     <style name="Theme.KekKek" parent="Base.Theme.KekKek" />


### PR DESCRIPTION
        <item name="android:windowDisablePreview">true</item>
        <item name="android:windowIsTranslucent">true</item>

SDK 31이하 스플래시 대응 (아이콘 숨기기)
SDK 31이하 기기가 없어서 실제 확인은 불가능, SDK30인 AVD에서는 문제없이 작동합니다.