### PR TITLE
[KEKKEK-36] reply 화면에서 액션마다 새로운 API 요청 하지 않는 방향성으로 문제 개선

### DIFF
--- a/app/src/main/java/com/stopsmoke/kekkek/core/data/mapper/PostMapper.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/data/mapper/PostMapper.kt
@@ -28,10 +28,7 @@ fun PostEntity.asExternalModel(): Post =
         ),
         title = title ?: "null",
         text = text ?: "null",
-        dateTime = DateTime(
-            created = dateTime?.created?.toLocalDateTime() ?: LocalDateTime.MIN,
-            modified = dateTime?.modified?.toLocalDateTime() ?: LocalDateTime.MIN
-        ),
+        dateTime = dateTime.asExternalModel(),
         likeUser = likeUser,
         unlikeUser = unlikeUser,
         category = when (category) {

--- a/app/src/main/java/com/stopsmoke/kekkek/core/data/repository/ReplyRepositoryImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/data/repository/ReplyRepositoryImpl.kt
@@ -19,13 +19,9 @@ class ReplyRepositoryImpl @Inject constructor(
     private val replyDao: ReplyDao,
     private val userRepository: UserRepository
 ) : ReplyRepository {
-    override suspend fun addReply(reply: Reply): Result<Unit> {
-        return try {
-            replyDao.addReply(reply.toEntity())
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
+
+    override suspend fun addReply(reply: Reply): String {
+        return replyDao.addReply(reply.toEntity())
     }
 
     override suspend fun getReply(commentId: String): Flow<PagingData<Reply>> {

--- a/app/src/main/java/com/stopsmoke/kekkek/core/domain/model/Comment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/domain/model/Comment.kt
@@ -1,7 +1,6 @@
 package com.stopsmoke.kekkek.core.domain.model
 
 import com.stopsmoke.kekkek.core.domain.getElapsedDateTime
-import java.time.LocalDateTime
 
 data class Comment(
     val id: String,
@@ -17,24 +16,3 @@ data class Comment(
 ) {
     val elapsedCreatedDateTime = dateTime.created.getElapsedDateTime()
 }
-
-fun emptyComment() = Comment(
-    id = "",
-    text = "",
-    dateTime = DateTime(
-        LocalDateTime.now(),
-        LocalDateTime.now()
-    ),
-    likeUser = emptyList(),
-    unlikeUser = emptyList(),
-    earliestReply = emptyList(),
-    written = Written(
-        "",
-        "",
-        ProfileImage.Default,
-        0
-    ),
-    parent = CommentParent(PostCategory.UNKNOWN, "", ""),
-    replyCount = 0,
-    isLiked = false
-)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/domain/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/domain/repository/ReplyRepository.kt
@@ -11,6 +11,8 @@ interface ReplyRepository {
      */
     suspend fun addReply(reply: Reply): String
 
+    fun getReply(postId: String, commentId: String, replyId: String) : Flow<Reply>
+
     suspend fun getReply(commentId: String): Flow<PagingData<Reply>>
 
     suspend fun deleteReply(reply: Reply)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/domain/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/domain/repository/ReplyRepository.kt
@@ -5,7 +5,11 @@ import com.stopsmoke.kekkek.core.domain.model.Reply
 import kotlinx.coroutines.flow.Flow
 
 interface ReplyRepository {
-    suspend fun addReply(reply: Reply): Result<Unit>
+
+    /**
+     * reply id 값을 리턴함
+     */
+    suspend fun addReply(reply: Reply): String
 
     suspend fun getReply(commentId: String): Flow<PagingData<Reply>>
 

--- a/app/src/main/java/com/stopsmoke/kekkek/core/domain/usecase/AddReplyUseCase.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/domain/usecase/AddReplyUseCase.kt
@@ -20,10 +20,10 @@ class AddReplyUseCase @Inject constructor(
         post: CommentParent,
         commentId: String,
         text: String,
-    ) {
+    ) : String{
         val user = userRepository.getUserData().first() as User.Registered
 
-        replyRepository.addReply(
+        return replyRepository.addReply(
             reply = Reply(
                 id = "",
                 written = Written(
@@ -34,7 +34,7 @@ class AddReplyUseCase @Inject constructor(
                 ),
                 likeUser = emptyList(),
                 unlikeUser = emptyList(),
-                dateTime = LocalDateTime.MIN.let { DateTime(it, it) },
+                dateTime = LocalDateTime.now().let { DateTime(it, it) },
                 text = text,
                 commentParent = post,
                 replyParent = commentId,

--- a/app/src/main/java/com/stopsmoke/kekkek/core/domain/usecase/AddReplyUseCase.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/domain/usecase/AddReplyUseCase.kt
@@ -1,0 +1,45 @@
+package com.stopsmoke.kekkek.core.domain.usecase
+
+import com.stopsmoke.kekkek.core.domain.model.CommentParent
+import com.stopsmoke.kekkek.core.domain.model.DateTime
+import com.stopsmoke.kekkek.core.domain.model.Reply
+import com.stopsmoke.kekkek.core.domain.model.User
+import com.stopsmoke.kekkek.core.domain.model.Written
+import com.stopsmoke.kekkek.core.domain.repository.ReplyRepository
+import com.stopsmoke.kekkek.core.domain.repository.UserRepository
+import kotlinx.coroutines.flow.first
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+class AddReplyUseCase @Inject constructor(
+    private val replyRepository: ReplyRepository,
+    private val userRepository: UserRepository
+) {
+
+    suspend operator fun invoke(
+        post: CommentParent,
+        commentId: String,
+        text: String,
+    ) {
+        val user = userRepository.getUserData().first() as User.Registered
+
+        replyRepository.addReply(
+            reply = Reply(
+                id = "",
+                written = Written(
+                    uid = user.uid,
+                    name = user.name,
+                    profileImage = user.profileImage,
+                    ranking = user.ranking
+                ),
+                likeUser = emptyList(),
+                unlikeUser = emptyList(),
+                dateTime = LocalDateTime.MIN.let { DateTime(it, it) },
+                text = text,
+                commentParent = post,
+                replyParent = commentId,
+                isLiked = false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/dao/ReplyDao.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/dao/ReplyDao.kt
@@ -5,7 +5,12 @@ import com.stopsmoke.kekkek.core.firestore.model.ReplyEntity
 import kotlinx.coroutines.flow.Flow
 
 interface ReplyDao {
-    suspend fun addReply(replyEntity: ReplyEntity)
+
+    /**
+     * reply id 값을 리턴함
+     */
+
+    suspend fun addReply(replyEntity: ReplyEntity) : String
 
     suspend fun getReply(commentId: String): Flow<PagingData<ReplyEntity>>
 

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/dao/ReplyDao.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/dao/ReplyDao.kt
@@ -12,6 +12,8 @@ interface ReplyDao {
 
     suspend fun addReply(replyEntity: ReplyEntity) : String
 
+    fun getReply(postId: String, commentId: String, replyId: String) : Flow<ReplyEntity>
+
     suspend fun getReply(commentId: String): Flow<PagingData<ReplyEntity>>
 
     suspend fun deleteReply(replyEntity: ReplyEntity)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.dataObjects
 import com.stopsmoke.kekkek.core.firestore.COMMENT_COLLECTION
 import com.stopsmoke.kekkek.core.firestore.POST_COLLECTION
 import com.stopsmoke.kekkek.core.firestore.REPLY_COLLECTION
@@ -14,19 +15,23 @@ import com.stopsmoke.kekkek.core.firestore.mapper.toInit
 import com.stopsmoke.kekkek.core.firestore.model.ReplyEntity
 import com.stopsmoke.kekkek.core.firestore.pager.FireStorePagingSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class ReplyDaoImpl @Inject constructor(
     private val firestore: FirebaseFirestore,
 ) : ReplyDao {
-    override suspend fun addReply(replyEntity: ReplyEntity) {
+    override suspend fun addReply(replyEntity: ReplyEntity): String {
+        var replyId: String
+
         firestore.collection(POST_COLLECTION)
             .document(replyEntity.commentParent!!.postId!!)
             .collection(COMMENT_COLLECTION)
             .document(replyEntity.replyParent!!)
             .collection(REPLY_COLLECTION)
             .document().let { documentReference ->
+                replyId = documentReference.id
                 val entity = replyEntity.copy(
                     id = documentReference.id,
                 )
@@ -34,6 +39,8 @@ class ReplyDaoImpl @Inject constructor(
                 documentReference.set(entity)
             }
             .await()
+        return replyId
+    }
 
     }
 

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
@@ -10,6 +10,7 @@ import com.stopsmoke.kekkek.core.firestore.COMMENT_COLLECTION
 import com.stopsmoke.kekkek.core.firestore.POST_COLLECTION
 import com.stopsmoke.kekkek.core.firestore.REPLY_COLLECTION
 import com.stopsmoke.kekkek.core.firestore.dao.ReplyDao
+import com.stopsmoke.kekkek.core.firestore.mapper.toInit
 import com.stopsmoke.kekkek.core.firestore.model.ReplyEntity
 import com.stopsmoke.kekkek.core.firestore.pager.FireStorePagingSource
 import kotlinx.coroutines.flow.Flow
@@ -26,9 +27,11 @@ class ReplyDaoImpl @Inject constructor(
             .document(replyEntity.replyParent!!)
             .collection(REPLY_COLLECTION)
             .document().let { documentReference ->
-                documentReference.set(
-                    replyEntity.copy(id = documentReference.id)
+                val entity = replyEntity.copy(
+                    id = documentReference.id,
                 )
+                    .toInit()
+                documentReference.set(entity)
             }
             .await()
 
@@ -76,7 +79,7 @@ class ReplyDaoImpl @Inject constructor(
         commentId: String,
         replyId: String,
         field: String,
-        items: List<Any>
+        items: List<Any>,
     ) {
         firestore.collection(POST_COLLECTION)
             .document(postId)
@@ -93,7 +96,7 @@ class ReplyDaoImpl @Inject constructor(
         commentId: String,
         replyId: String,
         field: String,
-        items: List<Any>
+        items: List<Any>,
     ) {
         firestore.collection(POST_COLLECTION)
             .document(postId)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/ReplyDaoImpl.kt
@@ -42,6 +42,19 @@ class ReplyDaoImpl @Inject constructor(
         return replyId
     }
 
+    override fun getReply(
+        postId: String,
+        commentId: String,
+        replyId: String,
+    ): Flow<ReplyEntity> {
+        return firestore.collection(POST_COLLECTION)
+            .document(postId)
+            .collection(COMMENT_COLLECTION)
+            .document(commentId)
+            .collection(REPLY_COLLECTION)
+            .document(replyId)
+            .dataObjects<ReplyEntity>()
+            .mapNotNull { it }
     }
 
     override suspend fun getReply(commentId: String): Flow<PagingData<ReplyEntity>> {

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/mapper/ReplyEntityMapper.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/mapper/ReplyEntityMapper.kt
@@ -1,0 +1,16 @@
+package com.stopsmoke.kekkek.core.firestore.mapper
+
+import com.stopsmoke.kekkek.core.firestore.model.InitDateTime
+import com.stopsmoke.kekkek.core.firestore.model.InitReplyEntity
+import com.stopsmoke.kekkek.core.firestore.model.ReplyEntity
+
+fun ReplyEntity.toInit() = InitReplyEntity(
+    id = id,
+    written = written,
+    likeUser = likeUser,
+    unlikeUser = unlikeUser,
+    dateTime = InitDateTime(),
+    text = text,
+    commentParent = commentParent,
+    replyParent = replyParent
+)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/model/InitDateTime.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/model/InitDateTime.kt
@@ -1,0 +1,11 @@
+package com.stopsmoke.kekkek.core.firestore.model
+
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.PropertyName
+
+data class InitDateTime(
+    @get:PropertyName("created") @set:PropertyName("created")
+    var created: FieldValue = FieldValue.serverTimestamp(),
+    @get:PropertyName("modified") @set:PropertyName("modified")
+    var modified: FieldValue = FieldValue.serverTimestamp(),
+)

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/model/InitReplyEntity.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/model/InitReplyEntity.kt
@@ -1,0 +1,29 @@
+package com.stopsmoke.kekkek.core.firestore.model
+
+import com.google.firebase.firestore.PropertyName
+
+data class InitReplyEntity(
+    @get:PropertyName("id") @set:PropertyName("id")
+    var id: String? = null,
+
+    @get:PropertyName("written") @set:PropertyName("written")
+    var written: WrittenEntity? = null,
+
+    @get:PropertyName("like_user") @set:PropertyName("like_user")
+    var likeUser: List<String> = emptyList(),
+
+    @get:PropertyName("unlike_user") @set:PropertyName("unlike_user")
+    var unlikeUser: List<String> = emptyList(),
+
+    @get:PropertyName("date_time") @set:PropertyName("date_time")
+    var dateTime: InitDateTime? = null,
+
+    @get:PropertyName("text") @set:PropertyName("text")
+    var text: String? = null,
+
+    @get:PropertyName("comment_parent") @set:PropertyName("comment_parent")
+    var commentParent: CommentParentEntity? = null,
+
+    @get:PropertyName("reply_parent") @set:PropertyName("reply_parent")
+    var replyParent: String? = null,
+)

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/adapter/PostDetailAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/adapter/PostDetailAdapter.kt
@@ -13,7 +13,7 @@ import com.stopsmoke.kekkek.presentation.post.detail.model.PostContentItem
 import com.stopsmoke.kekkek.presentation.post.detail.model.PostDetailCommentRecyclerViewUiState
 import com.stopsmoke.kekkek.presentation.post.detail.viewholder.PostCommentViewHolder
 import com.stopsmoke.kekkek.presentation.post.detail.viewholder.PostContentViewHolder
-import com.stopsmoke.kekkek.presentation.post.detail.viewholder.PostDeletedItemAdapter
+import com.stopsmoke.kekkek.presentation.post.detail.viewholder.RecyclerviewEmptyViewHolder
 import com.stopsmoke.kekkek.presentation.post.detail.viewholder.PostReplyViewHolder
 import com.stopsmoke.kekkek.presentation.utils.diffutil.PostDetailCommentRecyclerViewUiStateDiffUtil
 
@@ -78,7 +78,7 @@ class PostDetailAdapter :
                     parent,
                     false
                 )
-                PostDeletedItemAdapter(view)
+                RecyclerviewEmptyViewHolder(view)
             }
 
             else -> throw IllegalStateException()

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/viewholder/RecyclerviewEmptyViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/viewholder/RecyclerviewEmptyViewHolder.kt
@@ -3,4 +3,4 @@ package com.stopsmoke.kekkek.presentation.post.detail.viewholder
 import androidx.recyclerview.widget.RecyclerView
 import com.stopsmoke.kekkek.databinding.RecyclerviewEmptyBinding
 
-class PostDeletedItemAdapter(binding: RecyclerviewEmptyBinding): RecyclerView.ViewHolder(binding.root)
+class RecyclerviewEmptyViewHolder(binding: RecyclerviewEmptyBinding): RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/PreviewReplyAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/PreviewReplyAdapter.kt
@@ -3,19 +3,13 @@ package com.stopsmoke.kekkek.presentation.reply
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
+import com.stopsmoke.kekkek.core.domain.model.Reply
 import com.stopsmoke.kekkek.databinding.ItemReplyBinding
-import com.stopsmoke.kekkek.databinding.RecyclerviewEmptyBinding
-import com.stopsmoke.kekkek.presentation.post.detail.viewholder.RecyclerviewEmptyViewHolder
 import com.stopsmoke.kekkek.presentation.reply.callback.ReplyCallback
 import com.stopsmoke.kekkek.presentation.reply.viewholder.ReplyViewHolder
-import com.stopsmoke.kekkek.presentation.utils.diffutil.ReplyUiStateDiffUtil
+import com.stopsmoke.kekkek.presentation.utils.diffutil.ReplyDiffUtil
 
-private enum class PreviewReplyViewType {
-   REPLY, DELETED, ERROR
-}
-
-class PreviewReplyAdapter : ListAdapter<ReplyUiState, RecyclerView.ViewHolder>(ReplyUiStateDiffUtil()) {
+class PreviewReplyAdapter : ListAdapter<Reply, ReplyViewHolder>(ReplyDiffUtil()) {
 
     private var callback: ReplyCallback? = null
 
@@ -27,42 +21,17 @@ class PreviewReplyAdapter : ListAdapter<ReplyUiState, RecyclerView.ViewHolder>(R
         callback = null
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
-        when (viewType) {
-            PreviewReplyViewType.REPLY.ordinal -> {
-                val view = ItemReplyBinding.inflate(
-                    /* inflater = */ LayoutInflater.from(parent.context),
-                    /* parent = */ parent,
-                    /* attachToParent = */ false
-                )
-                ReplyViewHolder(view, callback)
-            }
-
-            else -> {
-                val view = RecyclerviewEmptyBinding.inflate(
-                    /* inflater = */ LayoutInflater.from(parent.context),
-                    /* parent = */ parent,
-                    /* attachToParent = */ false
-                )
-                RecyclerviewEmptyViewHolder(view)
-            }
-        }
-
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        val currentItem = getItem(position) ?: return
-
-        when (holder) {
-            is ReplyViewHolder -> {
-                holder.bind((currentItem as ReplyUiState.ReplyType).data)
-            }
-        }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReplyViewHolder {
+        val view = ItemReplyBinding.inflate(
+            /* inflater = */ LayoutInflater.from(parent.context),
+            /* parent = */ parent,
+            /* attachToParent = */ false
+        )
+        return ReplyViewHolder(view, callback)
     }
 
-    override fun getItemViewType(position: Int): Int {
-        return when (getItem(position)) {
-            is ReplyUiState.ReplyType -> PreviewReplyViewType.REPLY.ordinal
-            is ReplyUiState.ItemDeleted -> PreviewReplyViewType.DELETED.ordinal
-            null -> PreviewReplyViewType.ERROR.ordinal
-        }
+    override fun onBindViewHolder(holder: ReplyViewHolder, position: Int) {
+        val currentItem = getItem(position) ?: return
+        holder.bind(currentItem)
     }
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/PreviewReplyAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/PreviewReplyAdapter.kt
@@ -2,24 +2,20 @@ package com.stopsmoke.kekkek.presentation.reply
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.stopsmoke.kekkek.core.domain.model.Comment
-import com.stopsmoke.kekkek.databinding.ItemCommentBinding
 import com.stopsmoke.kekkek.databinding.ItemReplyBinding
 import com.stopsmoke.kekkek.databinding.RecyclerviewEmptyBinding
 import com.stopsmoke.kekkek.presentation.post.detail.viewholder.RecyclerviewEmptyViewHolder
 import com.stopsmoke.kekkek.presentation.reply.callback.ReplyCallback
-import com.stopsmoke.kekkek.presentation.reply.viewholder.CommentViewHolder
 import com.stopsmoke.kekkek.presentation.reply.viewholder.ReplyViewHolder
 import com.stopsmoke.kekkek.presentation.utils.diffutil.ReplyUiStateDiffUtil
 
-private enum class ReplyViewType {
-    COMMENT, REPLY, DELETED, ERROR
+private enum class PreviewReplyViewType {
+   REPLY, DELETED, ERROR
 }
 
-class ReplyAdapter :
-    PagingDataAdapter<ReplyUiState, RecyclerView.ViewHolder>(ReplyUiStateDiffUtil()) {
+class PreviewReplyAdapter : ListAdapter<ReplyUiState, RecyclerView.ViewHolder>(ReplyUiStateDiffUtil()) {
 
     private var callback: ReplyCallback? = null
 
@@ -31,25 +27,9 @@ class ReplyAdapter :
         callback = null
     }
 
-    private var comment: Comment? = null
-
-    fun updateComment(value: Comment) {
-        comment = value
-        notifyItemChanged(0)
-    }
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
         when (viewType) {
-            ReplyViewType.COMMENT.ordinal -> {
-                val view = ItemCommentBinding.inflate(
-                    /* inflater = */ LayoutInflater.from(parent.context),
-                    /* parent = */ parent,
-                    /* attachToParent = */ false
-                )
-                CommentViewHolder(view, callback)
-            }
-
-            ReplyViewType.REPLY.ordinal -> {
+            PreviewReplyViewType.REPLY.ordinal -> {
                 val view = ItemReplyBinding.inflate(
                     /* inflater = */ LayoutInflater.from(parent.context),
                     /* parent = */ parent,
@@ -72,26 +52,17 @@ class ReplyAdapter :
         val currentItem = getItem(position) ?: return
 
         when (holder) {
-            is CommentViewHolder -> {
-                comment?.let { holder.bind(it) }
-            }
-
             is ReplyViewHolder -> {
                 holder.bind((currentItem as ReplyUiState.ReplyType).data)
             }
         }
-
     }
 
     override fun getItemViewType(position: Int): Int {
-        if (position == 0) {
-            return ReplyViewType.COMMENT.ordinal
-        }
-
         return when (getItem(position)) {
-            is ReplyUiState.ReplyType -> ReplyViewType.REPLY.ordinal
-            is ReplyUiState.ItemDeleted -> ReplyViewType.DELETED.ordinal
-            null -> ReplyViewType.ERROR.ordinal
+            is ReplyUiState.ReplyType -> PreviewReplyViewType.REPLY.ordinal
+            is ReplyUiState.ItemDeleted -> PreviewReplyViewType.DELETED.ordinal
+            null -> PreviewReplyViewType.ERROR.ordinal
         }
     }
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.core.content.ContextCompat
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -54,7 +53,7 @@ class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback, ErrorHandl
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentReplyBinding.inflate(inflater, container, false)
         return binding.root
@@ -79,23 +78,25 @@ class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback, ErrorHandl
     }
 
     private fun initViewModel() = with(viewModel) {
-        reply.collectLatestWithLifecycle(lifecycle) {replyResult ->
-            when(replyResult){
+        reply.collectLatestWithLifecycle(lifecycle) { replyResult ->
+            when (replyResult) {
                 is Result.Error -> {
                     replyResult.exception?.printStackTrace()
                     errorExit(findNavController())
                 }
+
                 Result.Loading -> {}
                 is Result.Success -> replyAdapter.submitData(replyResult.data)
             }
         }
 
-        comment.collectLatestWithLifecycle(viewLifecycleOwner.lifecycle) {commentResult ->
-            when(commentResult){
+        comment.collectLatestWithLifecycle(viewLifecycleOwner.lifecycle) { commentResult ->
+            when (commentResult) {
                 is Result.Error -> {
                     commentResult.exception?.printStackTrace()
                     errorExit(findNavController())
                 }
+
                 Result.Loading -> {}
                 is Result.Success -> replyAdapter.updateComment()
                 null -> {}
@@ -127,7 +128,7 @@ class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback, ErrorHandl
         }
     }
 
-    private fun setBackBtn(){
+    private fun setBackBtn() {
         binding.includeFragmentReplyAppBar.ivPostCommentBack.setOnClickListener {
             findNavController().popBackStack()
         }
@@ -181,7 +182,7 @@ class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback, ErrorHandl
     }
 
     private fun showDeleteDialog(reply: Reply) {
-       val replyDeleteDialog = ReplyDeleteDialogFragment(this@ReplyFragment, reply)
+        val replyDeleteDialog = ReplyDeleteDialogFragment(this@ReplyFragment, reply)
         replyDeleteDialog.show(childFragmentManager, "replyDeleteDialog")
     }
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyUiState.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyUiState.kt
@@ -1,0 +1,10 @@
+package com.stopsmoke.kekkek.presentation.reply
+
+import com.stopsmoke.kekkek.core.domain.model.Reply
+
+sealed interface ReplyUiState {
+
+    data class ReplyType(val data: Reply) : ReplyUiState
+
+    data object ItemDeleted : ReplyUiState
+}

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyViewModel.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyViewModel.kt
@@ -16,6 +16,7 @@ import com.stopsmoke.kekkek.core.domain.model.emptyReply
 import com.stopsmoke.kekkek.core.domain.repository.CommentRepository
 import com.stopsmoke.kekkek.core.domain.repository.ReplyRepository
 import com.stopsmoke.kekkek.core.domain.repository.UserRepository
+import com.stopsmoke.kekkek.core.domain.usecase.AddReplyUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -38,6 +39,7 @@ class ReplyViewModel @Inject constructor(
     private val replyRepository: ReplyRepository,
     userRepository: UserRepository,
     private val commentRepository: CommentRepository,
+    private val addReplyUseCase: AddReplyUseCase
 ) : ViewModel() {
     val user: StateFlow<User?> = userRepository.getUserData()
         .catch { it.printStackTrace() }
@@ -104,31 +106,10 @@ class ReplyViewModel @Inject constructor(
 
     fun addReply(reply: String) = viewModelScope.launch {
         try {
-            if (comment.value == null) {
-                return@launch
-            }
-
-            val user = user.value as? User.Registered ?: return@launch
-            replyRepository.addReply(
-                reply = Reply(
-                    id = "",
-                    written = Written(
-                        uid = user.uid,
-                        name = user.name,
-                        profileImage = user.profileImage,
-                        ranking = user.ranking
-                    ),
-                    likeUser = emptyList(),
-                    unlikeUser = emptyList(),
-                    dateTime = DateTime(
-                        LocalDateTime.now(),
-                        LocalDateTime.now()
-                    ),
-                    text = reply,
-                    commentParent = (comment.value as Result.Success).data.parent,
-                    replyParent = (comment.value as Result.Success).data.id,
-                    isLiked = false
-                )
+            addReplyUseCase(
+                post = (comment.value as Result.Success).data.parent,
+                commentId = (comment.value as Result.Success).data.id,
+                text = reply
             )
         } catch (e: Exception) {
             e.printStackTrace()

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/callback/ReplyCallback.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/callback/ReplyCallback.kt
@@ -1,14 +1,13 @@
 package com.stopsmoke.kekkek.presentation.reply.callback
 
-import com.stopsmoke.kekkek.core.domain.model.Comment
 import com.stopsmoke.kekkek.core.domain.model.Reply
 
 interface ReplyCallback {
     fun deleteItem(reply: Reply)
 
-    fun updateReply(reply: Reply)
-
-    fun commentLikeClick(comment: Comment)
-
     fun navigateToUserProfile(uid: String)
+
+    fun setCommentLike(like: Boolean)
+
+    fun setReplyLike(id: String, like: Boolean)
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/viewholder/CommentViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/viewholder/CommentViewHolder.kt
@@ -1,0 +1,38 @@
+package com.stopsmoke.kekkek.presentation.reply.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.stopsmoke.kekkek.R
+import com.stopsmoke.kekkek.core.domain.model.Comment
+import com.stopsmoke.kekkek.databinding.ItemCommentBinding
+import com.stopsmoke.kekkek.presentation.reply.callback.ReplyCallback
+import com.stopsmoke.kekkek.presentation.setDefaultProfileImage
+import com.stopsmoke.kekkek.presentation.toResourceId
+import com.stopsmoke.kekkek.presentation.utils.handleImageColor
+
+class CommentViewHolder(
+    private val binding: ItemCommentBinding,
+    private val callback: ReplyCallback?,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(comment: Comment): Unit = with(binding) {
+        tvCommentNickname.text = comment.written.name
+        tvCommentDescription.text = comment.text
+        tvCommentHour.text = comment.elapsedCreatedDateTime.toResourceId(itemView.context)
+        ivCommentProfile.setDefaultProfileImage(comment.written.profileImage)
+        tvCommentLikeNum.text = comment.likeUser.size.toString()
+
+        ivCommentLike.handleImageColor(
+            context = itemView.context,
+            activeColor = R.color.primary_blue,
+            passiveColor = R.color.gray_lightgray2,
+            isActive = comment.isLiked
+        )
+
+        ivCommentProfile.setOnClickListener {
+            callback?.navigateToUserProfile(comment.written.uid)
+        }
+
+        clCommentLike.setOnClickListener {
+            callback?.setCommentLike(!comment.isLiked)
+        }
+    }
+}

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/viewholder/ReplyViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/viewholder/ReplyViewHolder.kt
@@ -1,0 +1,42 @@
+package com.stopsmoke.kekkek.presentation.reply.viewholder
+
+import androidx.recyclerview.widget.RecyclerView
+import com.stopsmoke.kekkek.R
+import com.stopsmoke.kekkek.core.domain.model.Reply
+import com.stopsmoke.kekkek.databinding.ItemReplyBinding
+import com.stopsmoke.kekkek.presentation.reply.callback.ReplyCallback
+import com.stopsmoke.kekkek.presentation.setDefaultProfileImage
+import com.stopsmoke.kekkek.presentation.toResourceId
+import com.stopsmoke.kekkek.presentation.utils.handleImageColor
+
+class ReplyViewHolder(
+    private val binding: ItemReplyBinding,
+    private val callback: ReplyCallback?,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(reply: Reply) = with(binding) {
+        tvCommentNickname.text = reply.written.name
+        tvCommentDescription.text = reply.text
+        tvCommentHour.text = reply.elapsedCreatedDateTime.toResourceId(itemView.context)
+        ivCommentProfile.setDefaultProfileImage(reply.written.profileImage)
+        tvCommentLikeNum.text = reply.likeUser.size.toString()
+        ivCommentLike.handleImageColor(
+            context = itemView.context,
+            activeColor = R.color.primary_blue,
+            passiveColor = R.color.gray_lightgray2,
+            isActive = reply.isLiked
+        )
+
+        ivCommentProfile.setOnClickListener {
+            callback?.navigateToUserProfile(reply.written.uid)
+        }
+
+        clCommentLike.setOnClickListener {
+            callback?.setReplyLike(reply.id, !reply.isLiked)
+        }
+
+        itemView.setOnLongClickListener {
+            callback?.deleteItem(reply)
+            true
+        }
+    }
+}

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/utils/ImageView.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/utils/ImageView.kt
@@ -1,0 +1,19 @@
+package com.stopsmoke.kekkek.presentation.utils
+
+import android.content.Context
+import android.widget.ImageView
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
+
+fun ImageView.handleImageColor(
+    context: Context,
+    @ColorRes activeColor: Int,
+    @ColorRes passiveColor: Int,
+    isActive: Boolean
+) {
+    if (isActive) {
+        setColorFilter(ContextCompat.getColor(context, activeColor))
+        return
+    }
+    setColorFilter(ContextCompat.getColor(context, passiveColor))
+}

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/utils/diffutil/ReplyUiStateDiffUtil.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/utils/diffutil/ReplyUiStateDiffUtil.kt
@@ -1,0 +1,30 @@
+package com.stopsmoke.kekkek.presentation.utils.diffutil
+
+import android.annotation.SuppressLint
+import androidx.recyclerview.widget.DiffUtil
+import com.stopsmoke.kekkek.presentation.reply.ReplyUiState
+
+class ReplyUiStateDiffUtil : DiffUtil.ItemCallback<ReplyUiState>() {
+    override fun areItemsTheSame(oldItem: ReplyUiState, newItem: ReplyUiState): Boolean {
+        return when(oldItem) {
+            is ReplyUiState.ItemDeleted -> {
+                when (newItem) {
+                    is ReplyUiState.ItemDeleted -> true
+                    is ReplyUiState.ReplyType -> false
+                }
+            }
+            is ReplyUiState.ReplyType -> {
+                when (newItem) {
+                    is ReplyUiState.ItemDeleted -> false
+                    is ReplyUiState.ReplyType -> oldItem.data.id == newItem.data.id
+                }
+            }
+        }
+    }
+
+    @SuppressLint("DiffUtilEquals")
+    override fun areContentsTheSame(oldItem: ReplyUiState, newItem: ReplyUiState): Boolean {
+        return oldItem === newItem
+    }
+
+}


### PR DESCRIPTION
대댓글 추가, 대댓글 좋아요 및 삭제 등등 action이 일어나는 경우
PagingAdapter의 refresh 요청을 하여 network api를 자주 요청하는 문제가 있었습니다

그래서 변경되는 부분만 api를 재요청하는 방식이 아닌 UI 상태 변화만 주었습니다