### PR TITLE
Feature/UI improv

### DIFF
--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestorage/data/StorageDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestorage/data/StorageDaoImpl.kt
@@ -38,7 +38,6 @@ internal class StorageDaoImpl @Inject constructor(
         reference.child(path).delete().apply {
             addOnSuccessListener(successListener)
             addOnFailureListener(failureListener)
-            await()
         }
 
         awaitClose()

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/PostDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/PostDaoImpl.kt
@@ -175,6 +175,8 @@ internal class PostDaoImpl @Inject constructor(
     }
 
     override suspend fun editPost(postEntity: PostEntity) {
+        storageDao.deleteFile("posts/${postEntity.id}")
+
         val updateMap = mapOf(
             "category" to postEntity.category,
             "title" to postEntity.title,

--- a/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/PostDaoImpl.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/core/firestore/data/PostDaoImpl.kt
@@ -180,6 +180,7 @@ internal class PostDaoImpl @Inject constructor(
             "title" to postEntity.title,
             "text" to postEntity.text,
             "date_time.modified" to FieldValue.serverTimestamp(),
+            "images_url" to emptyList<String>()
         )
         firestore.collection(POST_COLLECTION)
             .document(postEntity.id!!)

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.paging.map
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.stopsmoke.kekkek.R
@@ -236,7 +237,12 @@ class CommunityFragment : Fragment(), ErrorHandle {
                 }
 
                 Result.Loading -> {}
-                is Result.Success -> listAdapter.submitData(postsResult.data)
+                is Result.Success -> {
+                    val data = postsResult.data.map{
+                        it.toCommunityWritingListItem(requireContext())
+                    }
+                    listAdapter.submitData(data)
+                }
             }
 
         }
@@ -254,7 +260,8 @@ class CommunityFragment : Fragment(), ErrorHandle {
                         Result.Loading -> {}
                         is Result.Success -> bindPopularPosts(
                             popularPostsResult.data,
-                            period = true
+                            period = true,
+                            context = requireContext()
                         )
                     }
                 }
@@ -268,7 +275,7 @@ class CommunityFragment : Fragment(), ErrorHandle {
                 }
 
                 Result.Loading -> {}
-                is Result.Success -> bindPopularPosts(it.data, period = false)
+                is Result.Success -> bindPopularPosts(it.data, period = false, context = requireContext())
             }
         }
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityFragment.kt
@@ -19,7 +19,7 @@ import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentCommunityBinding
 import com.stopsmoke.kekkek.presentation.NavigationKey
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.notification.navigateToNotificationScreen
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
 import com.stopsmoke.kekkek.presentation.post.edit.navigateToPostEditScreen
@@ -36,7 +36,7 @@ import kotlinx.coroutines.launch
 
 
 @AndroidEntryPoint
-class CommunityFragment : Fragment(), ErrorHandle {
+class CommunityFragment : Fragment() {
     private var _binding: FragmentCommunityBinding? = null
     private val binding: FragmentCommunityBinding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListAdapter.kt
@@ -10,7 +10,7 @@ import coil.load
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.getRelativeTime
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.utils.diffutil.CommunityWritingItemDiffUtil
 
 class CommunityListAdapter :
@@ -69,7 +69,7 @@ class CommunityListAdapter :
                 }
             }
 
-            tvItemWritingPostType.text = item.postType.toStringKR() ?: ""
+            tvItemWritingPostType.text = item.postType.getResourceString(binding.root.context) ?: ""
 
             binding.circleIvItemWritingProfile.setOnClickListener {
                 callback?.navigateToUserProfile(item.userInfo.uid)

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListAdapter.kt
@@ -7,6 +7,7 @@ import android.widget.TextView
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.bumptech.glide.Glide
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.getRelativeTime
@@ -49,9 +50,16 @@ class CommunityListAdapter :
             tvItemWritingTimeStamp.text = getRelativeTime(item.postTime)
 
             item.userInfo.let {
-                it.profileImage.let { imgUrl ->
-                    if (imgUrl.isNullOrBlank()) circleIvItemWritingProfile.setImageResource(R.drawable.ic_user_profile_test)
-                    else circleIvItemWritingProfile.load(imgUrl)
+                it.profileImage?.let { imgUrl ->
+                    if (imgUrl.isNullOrBlank()) {
+                        circleIvItemWritingProfile.setImageResource(R.drawable.ic_user_profile_test)
+                    } else {
+                        Glide.with(itemView.context)
+                            .load(imgUrl)
+                            .into(circleIvItemWritingProfile)
+                    }
+                } ?: run {
+                    circleIvItemWritingProfile.setImageResource(R.drawable.ic_user_profile_test)
                 }
                 tvItemWritingName.text = it.name
                 tvItemWritingRank.text = "랭킹 ${it.rank}위"

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListItem.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityListItem.kt
@@ -1,12 +1,13 @@
 package com.stopsmoke.kekkek.presentation.community
 
+import android.content.Context
 import android.os.Parcelable
 import com.stopsmoke.kekkek.core.domain.model.DateTimeUnit
 import com.stopsmoke.kekkek.core.domain.model.ElapsedDateTime
 import com.stopsmoke.kekkek.core.domain.model.Post
 import com.stopsmoke.kekkek.core.domain.model.PostCategory
 import com.stopsmoke.kekkek.core.domain.model.ProfileImage
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
@@ -69,7 +70,7 @@ fun emptyCommunityWritingListItem() = CommunityWritingItem(
 )
 
 
-fun Post.toCommunityWritingListItem() = CommunityWritingItem(
+fun Post.toCommunityWritingListItem(context: Context) = CommunityWritingItem(
     userInfo = UserInfo(
         name = written.name,
         rank = written.ranking,
@@ -78,7 +79,7 @@ fun Post.toCommunityWritingListItem() = CommunityWritingItem(
     ),
     postInfo = PostInfo(
         title = title,
-        postType = category.toStringKR() ?: "",
+        postType = category.getResourceString(context) ?: "",
         view = views,
         like = likeUser.size.toLong(),
         comment = commentCount,
@@ -91,23 +92,24 @@ fun Post.toCommunityWritingListItem() = CommunityWritingItem(
 )
 
 
-fun Post.toCommunityWritingListItem(views: Long, commentNumber: Long) = CommunityWritingItem(
-    userInfo = UserInfo(
-        name = written.name,
-        rank = written.ranking,
-        profileImage = if (written.profileImage is ProfileImage.Web) written.profileImage.url else "",
-        uid = written.uid
-    ),
-    postInfo = PostInfo(
-        title = title,
-        postType = category.toStringKR() ?: "",
-        view = views,
-        like = likeUser.size.toLong(),
-        comment = commentNumber,
-        id = id
-    ),
-    postImage = "",
-    post = text,
-    postTime = modifiedElapsedDateTime,
-    postType = category
-)
+fun Post.toCommunityWritingListItem(views: Long, commentNumber: Long, context: Context) =
+    CommunityWritingItem(
+        userInfo = UserInfo(
+            name = written.name,
+            rank = written.ranking,
+            profileImage = if (written.profileImage is ProfileImage.Web) written.profileImage.url else "",
+            uid = written.uid
+        ),
+        postInfo = PostInfo(
+            title = title,
+            postType = category.getResourceString(context) ?: "",
+            view = views,
+            like = likeUser.size.toLong(),
+            comment = commentNumber,
+            id = id
+        ),
+        postImage = "",
+        post = text,
+        postTime = modifiedElapsedDateTime,
+        postType = category
+    )

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityViewModel.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/community/CommunityViewModel.kt
@@ -1,5 +1,6 @@
 package com.stopsmoke.kekkek.presentation.community
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
@@ -45,11 +46,6 @@ class CommunityViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val posts = category.flatMapLatest { postCategory ->
         postRepository.getPost(postCategory)
-            .map { pagingData ->
-                pagingData.map { post ->
-                    post.toCommunityWritingListItem()
-                }
-            }
     }
         .cachedIn(viewModelScope)
         .asResult()
@@ -64,19 +60,19 @@ class CommunityViewModel @Inject constructor(
         postRepository.getPopularPostListNonPeriod().asResult()
     }
 
-    fun bindPopularPosts(popularList: List<Post>, period: Boolean) {
+    fun bindPopularPosts(popularList: List<Post>, period: Boolean, context: Context) {
         (communityUiState.value as? CommunityUiState.CommunityNormalUiState)?.let {
             _communityUiState.update {
                 when (period) {
                     true -> {
                         (it as CommunityUiState.CommunityNormalUiState).copy(
-                            popularItem = popularList.map { it.toCommunityWritingListItem() },
+                            popularItem = popularList.map { it.toCommunityWritingListItem(context) },
                             popularPeriod = if (popularList.size < 2) false else true
                         )
                     }
 
                     false -> (it as CommunityUiState.CommunityNormalUiState).copy(
-                        popularItemNonPeriod = popularList.map { it.toCommunityWritingListItem() },
+                        popularItemNonPeriod = popularList.map { it.toCommunityWritingListItem(context) },
                     )
                 }
             }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/error/ErrorHandle.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/error/ErrorHandle.kt
@@ -2,17 +2,15 @@ package com.stopsmoke.kekkek.presentation.error
 
 import androidx.navigation.NavController
 
-interface ErrorHandle {
-    fun errorExit(navController: NavController) {
-        navController.navigate("errorServerEtc") {
-            popUpTo(navController.graph.id) {
-                inclusive = true
-            }
-            launchSingleTop = true
+fun errorExit(navController: NavController) {
+    navController.navigate("errorServerEtc") {
+        popUpTo(navController.graph.id) {
+            inclusive = true
         }
+        launchSingleTop = true
     }
+}
 
-    fun errorMissing(navController: NavController){
-        navController.navigate("errorMissing")
-    }
+fun errorMissing(navController: NavController) {
+    navController.navigate("errorMissing")
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/home/HomeFragment.kt
@@ -21,7 +21,7 @@ import com.stopsmoke.kekkek.core.domain.model.User
 import com.stopsmoke.kekkek.databinding.FragmentHomeBinding
 import com.stopsmoke.kekkek.presentation.attainments.navigateToAttainmentsScreen
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.home.center.navigateToHomeCenterScreen
 import com.stopsmoke.kekkek.presentation.home.dialog.HomeTimerStartDialogFragment
 import com.stopsmoke.kekkek.presentation.home.dialog.HomeTimerStopDialogFragment
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class HomeFragment : Fragment(), ErrorHandle {
+class HomeFragment : Fragment() {
 
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/home/HomeViewModel.kt
@@ -41,7 +41,8 @@ class HomeViewModel @Inject constructor(
     private var savedLifePerMinute: Double = 0.0
 
     private var _currentUserState = MutableStateFlow<User>(
-        User.Guest)
+        User.Guest
+    )
     val currentUserState = _currentUserState.asStateFlow()
 
     val user = userRepository.getUserData().stateIn(
@@ -230,7 +231,24 @@ class HomeViewModel @Inject constructor(
 
     fun getMyRank() {
         (user.value as? User.Registered)?.let {
-            _myRank.value = userList.value.filter{it.startTime != null}.sortedBy { it.startTime }.indexOf(it.toRankingListItem()) + 1
+            _myRank.value = userList.value.filter { it.startTime != null }.sortedBy { it.startTime }
+                .indexOf(it.toRankingListItem()) + 1
+        }
+    }
+
+    private val _rankingProgress = MutableStateFlow<Int>(0)
+    val rankingProgress get() = _rankingProgress.asStateFlow()
+
+    fun resetRankingProgress() = viewModelScope.launch {
+        _rankingProgress.emit(0)
+    }
+
+    fun proceedProgress() = viewModelScope.launch{
+        viewModelScope.launch {
+            while (_rankingProgress.value < 100) {
+                _rankingProgress.emit(_rankingProgress.value + 1)
+                delay(5)
+            }
         }
     }
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/mapper/PostCategortMapper.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/mapper/PostCategortMapper.kt
@@ -40,13 +40,3 @@ internal fun PostCategory.getResourceString(context: Context) = when(this) {
     PostCategory.UNKNOWN -> context.getString(R.string.community_category_unknown)
     PostCategory.ALL -> context.getString(R.string.community_category_all)
 }
-
-fun PostCategory.toStringKR(): String? = when (this) {
-    PostCategory.NOTICE -> "공지사항"
-    PostCategory.QUIT_SMOKING_AIDS_REVIEWS -> "금연 보조제 후기"
-    PostCategory.SUCCESS_STORIES -> "금연 성공 후기"
-    PostCategory.GENERAL_DISCUSSION -> "자유 게시판"
-    PostCategory.RESOLUTIONS -> "금연 다짐"
-    PostCategory.UNKNOWN -> null
-    PostCategory.ALL -> "커뮤니티 홈"
-}

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/MyFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/MyFragment.kt
@@ -31,7 +31,7 @@ import com.stopsmoke.kekkek.presentation.my.supportcenter.navigateToSupportCente
 import com.stopsmoke.kekkek.presentation.notification.navigateToNotificationScreen
 import com.stopsmoke.kekkek.presentation.settings.navigateToSettingsGraph
 import com.stopsmoke.kekkek.presentation.settings.profile.navigateToSettingsProfileScreen
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 
 
 @AndroidEntryPoint
-class MyFragment : Fragment(), ErrorHandle {
+class MyFragment : Fragment() {
     private var _binding: FragmentMyBinding? = null
     private val binding: FragmentMyBinding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/MyViewModel.kt
@@ -144,7 +144,7 @@ class MyViewModel @Inject constructor(
                                 user = userData.getTotalDay(),
                                 comment = activities.commentCount,
                                 post = activities.postCount,
-                                rank = userRank.toLong(),
+                                rank = if(userRank.toLong() == 0L) 9999 else userRank.toLong(),
                                 achievement = userData.clearAchievementsList.size.toLong()
                             )
                         }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/achievement/AchievementFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/achievement/AchievementFragment.kt
@@ -13,7 +13,7 @@ import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.core.domain.model.User
 import com.stopsmoke.kekkek.databinding.FragmentAchievementBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.my.MyViewModel
 import com.stopsmoke.kekkek.presentation.my.achievement.adapter.AchievementListAdapter
@@ -21,7 +21,7 @@ import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class AchievementFragment : Fragment(), ErrorHandle {
+class AchievementFragment : Fragment() {
 
     private var _binding: FragmentAchievementBinding? = null
     private val binding: FragmentAchievementBinding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkFragment.kt
@@ -18,7 +18,7 @@ import com.stopsmoke.kekkek.databinding.FragmentBookmarkBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.toCommunityWritingListItem
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.isVisible
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
@@ -28,7 +28,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class BookmarkFragment : Fragment(), ErrorHandle {
+class BookmarkFragment : Fragment() {
 
     @Inject
     lateinit var userRepository: UserRepository

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkFragment.kt
@@ -93,7 +93,7 @@ class BookmarkFragment : Fragment(), ErrorHandle {
                     errorExit(findNavController())
                 }
                 Result.Loading -> {}
-                is Result.Success -> listAdapter.submitData(bookmarkResult.data.map { pagingData -> pagingData.toCommunityWritingListItem() })
+                is Result.Success -> listAdapter.submitData(bookmarkResult.data.map { pagingData -> pagingData.toCommunityWritingListItem(requireContext()) })
             }
         }
     }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkListViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/bookmark/BookmarkListViewHolder.kt
@@ -10,7 +10,7 @@ import com.stopsmoke.kekkek.core.domain.model.ElapsedDateTime
 import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.CommunityWritingItem
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 
 class BookmarkListViewHolder(
     private val binding: ItemPostBinding,
@@ -38,7 +38,7 @@ class BookmarkListViewHolder(
                 ivItemWritingPostImage.visibility = View.GONE
                 setMarginEnd(tvItemWritingTitle, 16)
             }
-            tvItemWritingPostType.text = item.postType.toStringKR()
+            tvItemWritingPostType.text = item.postType.getResourceString(binding.root.context)
             tvItemWritingName.text = it.name
             tvItemWritingRank.text = "랭킹 ${it.rank}위"
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/comment/MyCommentFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/comment/MyCommentFragment.kt
@@ -15,7 +15,7 @@ import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentMyCommentBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.isVisible
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
@@ -24,7 +24,7 @@ import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MyCommentFragment : Fragment(), ErrorHandle {
+class MyCommentFragment : Fragment() {
 
     private var _binding: FragmentMyCommentBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/post/MyPostFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/post/MyPostFragment.kt
@@ -15,7 +15,7 @@ import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentMyPostBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.isVisible
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
@@ -23,7 +23,7 @@ import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MyPostFragment : Fragment(), ErrorHandle {
+class MyPostFragment : Fragment() {
     private var _binding: FragmentMyPostBinding? = null
     private val binding: FragmentMyPostBinding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/post/MyPostViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/post/MyPostViewHolder.kt
@@ -11,8 +11,8 @@ import com.stopsmoke.kekkek.core.domain.model.Post
 import com.stopsmoke.kekkek.core.domain.model.ProfileImage
 import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.toResourceId
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
 
 class MyPostViewHolder(
     private val binding: ItemPostBinding,
@@ -64,7 +64,7 @@ class MyPostViewHolder(
 //                tvItemWritingRank.text = "랭킹 ${it.rank}위"
 //            }
 
-        tvItemWritingPostType.text = item.category.toStringKR()
+        tvItemWritingPostType.text = item.category.getResourceString(binding.root.context)
     }
 
     private fun getRelativeTime(pastTime: ElapsedDateTime): String {

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/my/smokingsetting/SmokingSettingFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/my/smokingsetting/SmokingSettingFragment.kt
@@ -12,10 +12,10 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.stopsmoke.kekkek.databinding.FragmentSmokingSettingBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 
-class SmokingSettingFragment : Fragment(), ErrorHandle {
+class SmokingSettingFragment : Fragment() {
 
     private var _binding: FragmentSmokingSettingBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/PostDetailFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/PostDetailFragment.kt
@@ -25,7 +25,8 @@ import com.stopsmoke.kekkek.presentation.NavigationKey
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.dialog.CommonDialogFragment
 import com.stopsmoke.kekkek.presentation.dialog.CommonDialogListener
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
+import com.stopsmoke.kekkek.presentation.error.errorMissing
 import com.stopsmoke.kekkek.presentation.hideSoftKeyboard
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.my.complaint.navigateToMyComplaintScreen
@@ -44,7 +45,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class PostDetailFragment : Fragment(), PostCommentCallback, ErrorHandle {
+class PostDetailFragment : Fragment(), PostCommentCallback {
 
     private var _binding: FragmentPostDetailBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/viewholder/PostContentViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/detail/viewholder/PostContentViewHolder.kt
@@ -4,17 +4,16 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.MobileAds
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.core.domain.model.Post
 import com.stopsmoke.kekkek.core.domain.model.ProfileImage
 import com.stopsmoke.kekkek.core.domain.model.User
 import com.stopsmoke.kekkek.databinding.RecyclerviewPostviewContentBinding
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.post.detail.callback.PostCommentCallback
 import com.stopsmoke.kekkek.presentation.post.detail.model.PostContentItem
 import com.stopsmoke.kekkek.presentation.snackbarLongShow
 import com.stopsmoke.kekkek.presentation.toResourceId
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
 
 class PostContentViewHolder(
     private val binding: RecyclerviewPostviewContentBinding,
@@ -76,7 +75,7 @@ class PostContentViewHolder(
         if (post == null) return@with
 
         tvPostPosterNickname.text = post.written.name
-        tvPostPosterPostType.text = post.category.toStringKR()
+        tvPostPosterPostType.text = post.category.getResourceString(binding.root.context)
         tvPostPosterRanking.text = "랭킹 ${post.written.ranking}위"
         tvPostHour.text = post.modifiedElapsedDateTime.toResourceId(itemView.context)
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/edit/PostEditFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/edit/PostEditFragment.kt
@@ -37,10 +37,10 @@ import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.dialog.CircularProgressDialogFragment
 import com.stopsmoke.kekkek.presentation.error.ErrorHandle
 import com.stopsmoke.kekkek.presentation.invisible
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.mapper.toPostWriteCategory
 import com.stopsmoke.kekkek.presentation.post.edit.dialog.PostEditBottomSheetDialog
 import com.stopsmoke.kekkek.presentation.putNavigationResult
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -223,7 +223,7 @@ class PostEditFragment : Fragment(), ErrorHandle {
         etPostWriteContent.setText(post.text)
         etPostWriteTitle.setText(post.title)
 
-        tvPostWriteCategory.text = post.category.toStringKR()
+        tvPostWriteCategory.text = post.category.getResourceString(requireContext())
 
         includePostEditAppBar.tvPostEditRegister.text = "수정"
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/edit/PostEditFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/edit/PostEditFragment.kt
@@ -35,7 +35,7 @@ import com.stopsmoke.kekkek.databinding.FragmentPostEditBinding
 import com.stopsmoke.kekkek.presentation.NavigationKey
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.dialog.CircularProgressDialogFragment
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.mapper.toPostWriteCategory
@@ -50,7 +50,7 @@ import java.io.InputStream
 import java.time.LocalDateTime
 
 @AndroidEntryPoint
-class PostEditFragment : Fragment(), ErrorHandle {
+class PostEditFragment : Fragment() {
 
     private var _binding: FragmentPostEditBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListAdapter.kt
@@ -7,14 +7,11 @@ import android.widget.TextView
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
-import com.stopsmoke.kekkek.core.domain.model.DateTimeUnit
-import com.stopsmoke.kekkek.core.domain.model.ElapsedDateTime
-import com.stopsmoke.kekkek.core.domain.model.PostCategory
 import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.CommunityWritingItem
 import com.stopsmoke.kekkek.presentation.getRelativeTime
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 import com.stopsmoke.kekkek.presentation.utils.diffutil.CommunityWritingItemDiffUtil
 
 class NoticeListAdapter
@@ -66,7 +63,7 @@ class NoticeListAdapter
                 circleIvItemWritingProfile.load(it.profileImage)
             }
 
-            tvItemWritingPostType.text = item.postType.toStringKR()
+            tvItemWritingPostType.text = item.postType.getResourceString(binding.root.context)
 
             binding.root.setOnClickListener {
                 callback?.navigateToPost(item.postInfo.id)

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListFragment.kt
@@ -12,11 +12,13 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.paging.map
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentNoticeListBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
+import com.stopsmoke.kekkek.presentation.community.toCommunityWritingListItem
 import com.stopsmoke.kekkek.presentation.error.ErrorHandle
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.isVisible
@@ -101,7 +103,7 @@ class NoticeListFragment : Fragment(), ErrorHandle {
                             errorExit(findNavController())
                         }
                         Result.Loading -> {}
-                        is Result.Success -> listAdapter.submitData(noticePostsResult.data)
+                        is Result.Success -> listAdapter.submitData(noticePostsResult.data.map{it.toCommunityWritingListItem(requireContext())})
                     }
                 }
         }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListFragment.kt
@@ -19,7 +19,7 @@ import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentNoticeListBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.toCommunityWritingListItem
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.isVisible
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.collectLatest
 
 
 @AndroidEntryPoint
-class NoticeListFragment : Fragment(), ErrorHandle {
+class NoticeListFragment : Fragment() {
     private var _binding: FragmentNoticeListBinding? = null
     val binding: FragmentNoticeListBinding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListViewModel.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/notice/NoticeListViewModel.kt
@@ -22,11 +22,6 @@ class NoticeListViewModel @Inject constructor(
 
     val noticePosts =
         postRepository.getPost(category = PostCategory.NOTICE)
-            .map { pagingData ->
-                pagingData.map { post ->
-                    post.toCommunityWritingListItem()
-                }
-            }
             .cachedIn(viewModelScope)
             .asResult()
 }

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/popular/PopularPostFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/popular/PopularPostFragment.kt
@@ -16,7 +16,7 @@ import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.CommunityUiState
 import com.stopsmoke.kekkek.presentation.community.CommunityViewModel
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
 import com.stopsmoke.kekkek.presentation.userprofile.navigateToUserProfileScreen
@@ -24,7 +24,7 @@ import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class PopularPostFragment : Fragment(),ErrorHandle {
+class PopularPostFragment : Fragment() {
     private var _binding: FragmentPopularPostBinding? = null
     val binding: FragmentPopularPostBinding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/post/popular/PopularPostListViewHolder.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/post/popular/PopularPostListViewHolder.kt
@@ -10,7 +10,7 @@ import com.stopsmoke.kekkek.databinding.ItemPostBinding
 import com.stopsmoke.kekkek.presentation.community.CommunityCallbackListener
 import com.stopsmoke.kekkek.presentation.community.CommunityWritingItem
 import com.stopsmoke.kekkek.presentation.getRelativeTime
-import com.stopsmoke.kekkek.presentation.mapper.toStringKR
+import com.stopsmoke.kekkek.presentation.mapper.getResourceString
 
 class PopularPostListViewHolder(
     private val binding: ItemPostBinding,
@@ -48,7 +48,7 @@ class PopularPostListViewHolder(
             }
         }
 
-        tvItemWritingPostType.text = item.postType.toStringKR()
+        tvItemWritingPostType.text = item.postType.getResourceString(binding.root.context)
 
 
         binding.circleIvItemWritingProfile.setOnClickListener {

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/ranking/RankingListAdapter.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/ranking/RankingListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.bumptech.glide.Glide
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.databinding.RecyclerviewRankinglistRankstateItemBinding
 import com.stopsmoke.kekkek.presentation.ranking.field.RankingListField
@@ -39,7 +40,9 @@ class RankingListAdapter(
                     R.drawable.img_defaultprofile
                 )
             } else {
-                circleIvRankStateItemProfile.load(item.profileImage)
+                Glide.with(itemView.context)
+                    .load(item.profileImage)
+                    .into(circleIvRankStateItemProfile)
             }
 
             tvRankingListTime.text = when(rankingListField) {

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/ranking/RankingListFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/ranking/RankingListFragment.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.databinding.FragmentRankingListBinding
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.home.HomeUiState
 import com.stopsmoke.kekkek.presentation.home.HomeViewModel
 import com.stopsmoke.kekkek.presentation.invisible
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class RankingListFragment : Fragment(), RankingListCallback, ErrorHandle {
+class RankingListFragment : Fragment(), RankingListCallback {
     private var _binding: FragmentRankingListBinding? = null
     private val binding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/reply/ReplyFragment.kt
@@ -18,7 +18,7 @@ import com.stopsmoke.kekkek.core.domain.model.Reply
 import com.stopsmoke.kekkek.core.domain.model.User
 import com.stopsmoke.kekkek.databinding.FragmentReplyBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.invisible
 import com.stopsmoke.kekkek.presentation.reply.callback.ReplyCallback
 import com.stopsmoke.kekkek.presentation.reply.callback.ReplyDialogCallback
@@ -29,7 +29,7 @@ import com.stopsmoke.kekkek.presentation.visible
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback, ErrorHandle {
+class ReplyFragment : Fragment(), ReplyCallback, ReplyDialogCallback {
     private var _binding: FragmentReplyBinding? = null
     private val binding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/search/post/SearchPostFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/search/post/SearchPostFragment.kt
@@ -13,11 +13,11 @@ import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentSearchPostBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.post.detail.navigateToPostDetailScreen
 import com.stopsmoke.kekkek.presentation.search.SearchViewModel
 
-class SearchPostFragment : Fragment(), ErrorHandle {
+class SearchPostFragment : Fragment() {
 
     private var _binding: FragmentSearchPostBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/smokingaddictiontest/result/SmokingAddictionTestResultFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/smokingaddictiontest/result/SmokingAddictionTestResultFragment.kt
@@ -10,13 +10,13 @@ import androidx.navigation.fragment.findNavController
 import com.stopsmoke.kekkek.R
 import com.stopsmoke.kekkek.databinding.FragmentSmokingAddictionTestResultBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.smokingaddictiontest.SmokingAddictionTestUiState
 import com.stopsmoke.kekkek.presentation.home.popBackStackInclusiveHome
 import com.stopsmoke.kekkek.presentation.smokingaddictiontest.SmokingAddictionTestViewModel
 import com.stopsmoke.kekkek.presentation.smokingaddictiontest.model.SmokingQuestionnaireUiState
 
-class SmokingAddictionTestResultFragment : Fragment(), ErrorHandle {
+class SmokingAddictionTestResultFragment : Fragment() {
 
     private var _binding: FragmentSmokingAddictionTestResultBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/achievement/UserProfileAchievementFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/achievement/UserProfileAchievementFragment.kt
@@ -11,13 +11,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentUserProfileAchievementBinding
 import com.stopsmoke.kekkek.presentation.collectLatestWithLifecycle
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.my.achievement.AchievementItem
 import com.stopsmoke.kekkek.presentation.userprofile.UserProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class UserProfileAchievementFragment : Fragment(),ErrorHandle {
+class UserProfileAchievementFragment : Fragment() {
     private var _binding: FragmentUserProfileAchievementBinding? = null
     private val binding get() = _binding!!
 

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/comment/UserProfileCommentFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/comment/UserProfileCommentFragment.kt
@@ -11,12 +11,12 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentUserProfileCommentBinding
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.userprofile.UserProfileViewModel
 import com.stopsmoke.kekkek.presentation.userprofile.comment.adapter.UserProfileCommentListAdapter
 import kotlinx.coroutines.launch
 
-class UserProfileCommentFragment : Fragment(), ErrorHandle {
+class UserProfileCommentFragment : Fragment() {
 
     private var _binding: FragmentUserProfileCommentBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/post/UserProfilePostFragment.kt
+++ b/app/src/main/java/com/stopsmoke/kekkek/presentation/userprofile/post/UserProfilePostFragment.kt
@@ -11,13 +11,13 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stopsmoke.kekkek.common.Result
 import com.stopsmoke.kekkek.databinding.FragmentUserProfilePostBinding
-import com.stopsmoke.kekkek.presentation.error.ErrorHandle
+import com.stopsmoke.kekkek.presentation.error.errorExit
 import com.stopsmoke.kekkek.presentation.userprofile.UserProfileViewModel
 import com.stopsmoke.kekkek.presentation.userprofile.post.adapter.UserPostListAdapter
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class UserProfilePostFragment : Fragment(), ErrorHandle {
+class UserProfilePostFragment : Fragment() {
 
     private var _binding: FragmentUserProfilePostBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/res/layout/fragment_post_edit.xml
+++ b/app/src/main/res/layout/fragment_post_edit.xml
@@ -36,7 +36,6 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:src="@drawable/ic_dropdown"
-            android:tint="@color/gray_lightgray2"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -129,7 +128,6 @@
             android:layout_height="24dp"
             android:layout_margin="8dp"
             android:src="@drawable/ic_delete"
-            android:visibility="gone"
             app:layout_constraintEnd_toEndOf="@+id/cv_post_write_image"
             app:layout_constraintTop_toBottomOf="@+id/et_post_write_content"
             tools:visibility="visible" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="community_category_failure_stories">금연 실패 후기</string>
     <string name="community_category_resolutions">금연 다짐</string>
     <string name="community_category_unknown">알 수 없는 에러</string>
-    <string name="community_category_all">전체</string>
+    <string name="community_category_all">커뮤니티 홈</string>
 
     <string name="search_recommend_keyword">님을 위한 추천 검색어</string>
     <string name="search_guest_recommend_keyword">당신을 위한 추천 검색어</string>


### PR DESCRIPTION
storageDao.deleteImage 함수 삭제가 제대로 안되는 것 같습니다. 그래서 포스트 필드값을  "images_url" to emptyList<String>()로 추가해두었습니다. 수요일 오전에 왜 삭제가 안되는 지 확인해보겠습니다.

프로필 이미지 재사용 문제는 coil 사용시만 문제가 발생해서 메모리 캐싱문제인가 해서 memoryCachePolicy(CachePolicy.DiSABLE)를 추가해봤는데도 문제가 해결이 안되서 랭킹, 커뮤니티 어뎁터에서 glide로 변경했습니다.